### PR TITLE
Allow arbitrary shell script / executable workflows

### DIFF
--- a/crunch/client/main.py
+++ b/crunch/client/main.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import json
 from pathlib import Path
 from typing import Optional
@@ -54,8 +55,11 @@ cores_arg = typer.Option(
     "1",
     help="The maximum number of cores/jobs to use to run the workflow. If 'all' then it uses all available cores.",
 )
-snakefile_arg = typer.Option(..., help="The path to the snakemake file.")
+path_arg = typer.Option(..., help="The path to the workflow file.")
 
+class WorkflowType(str, Enum):
+    snakemake = "snakemake"
+    script = "script"
 
 @app.command()
 def run(
@@ -66,7 +70,8 @@ def run(
     cores: str = cores_arg,
     url: str = url_arg,
     token: str = token_arg,
-    snakefile: Path = typer.Option(None, help="The path to the snakemake file."),
+    workflow: WorkflowType = typer.Option("snakemake", help="Workflow type (snakemake/script)."),
+    path: Path = typer.Option(None, help="The path to the workflow file."),
 ):
     """
     Processes a dataset.
@@ -118,12 +123,15 @@ def run(
             dataset_data["base_file_path"], directory, storage=storage
         )
 
-        # get snakefile
-        if not snakefile:
-            assert project_data["snakefile"]
-            snakefile = directory / "Snakefile"
-            with open(snakefile, "w", encoding="utf-8") as f:
-                f.write(project_data["snakefile"])
+        # get snakefile or script
+        if not path:
+            assert project_data["workflow"]
+            if workflow == WorkflowType.snakemake:
+                path = directory / "Snakefile"
+            elif workflow == WorkflowType.script:
+                path = directory / "script.sh"
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(project_data["workflow"])
 
         connection.send_status(dataset_id, stage=stage, state=State.SUCCESS)
     except Exception as e:
@@ -139,26 +147,29 @@ def run(
 
     try:
         connection.send_status(dataset_id, stage=stage, state=State.START)
-        import snakemake
+        if workflow == WorkflowType.snakemake:
+            import snakemake
 
-        args = [
-            f"--snakefile={snakefile}",
-            "--use-conda",
-            f"--cores={cores}",
-            f"--directory={directory}",
-        ]
-        mamba_found = True
-        try:
-            subprocess.run(["mamba", "--version"], capture_output=True, check=True)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            mamba_found = False
-        if not mamba_found:
-            args.append("--conda-frontend=conda")
+            args = [
+                f"--snakefile={path}",
+                "--use-conda",
+                f"--cores={cores}",
+                f"--directory={directory}",
+            ]
+            mamba_found = True
+            try:
+                subprocess.run(["mamba", "--version"], capture_output=True, check=True)
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                mamba_found = False
+            if not mamba_found:
+                args.append("--conda-frontend=conda")
 
-        try:
-            snakemake.main(args)
-        except SystemExit as result:
-            print(f"result {result}")
+            try:
+                snakemake.main(args)
+            except SystemExit as result:
+                print(f"result {result}")
+        elif workflow == WorkflowType.script:
+            subprocess.run(f"{path}", capture_output=True, check=True)
 
         connection.send_status(dataset_id, stage=stage, state=State.SUCCESS)
     except Exception as e:
@@ -195,7 +206,7 @@ def next(
         "",
         help="The slug for a project the dataset is in. If not given, then it chooses any project.",
     ),
-    snakefile: Path = snakefile_arg,
+    path: Path = path_arg,
 ):
     """
     Processes the next dataset in a project.
@@ -219,7 +230,7 @@ def next(
             token=token,
             directory=directory,
             cores=cores,
-            snakefile=snakefile,
+            path=path,
         )
     else:
         console.print("No more datasets to process.")
@@ -232,7 +243,7 @@ def loop(
     cores: str = cores_arg,
     url: str = url_arg,
     token: str = token_arg,
-    snakefile: Path = snakefile_arg,
+    path: Path = path_arg,
 ):
     """
     Loops through all the datasets in a project and stops when complete.
@@ -247,7 +258,7 @@ def loop(
             storage_settings=storage_settings,
             directory=directory,
             cores=cores,
-            snakefile=snakefile,
+            path=path,
         )
         if result is None:
             console.print("Loop concluded.")

--- a/crunch/client/main.py
+++ b/crunch/client/main.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import json
 from pathlib import Path
+import stat
 from typing import Optional
 import traceback
 from typing import List
@@ -132,6 +133,8 @@ def run(
                 path = directory / "script.sh"
             with open(path, "w", encoding="utf-8") as f:
                 f.write(project_data["workflow"])
+            if workflow == WorkflowType.script:
+                path.chmod(path.stat().st_mode | stat.S_IEXEC)
 
         connection.send_status(dataset_id, stage=stage, state=State.SUCCESS)
     except Exception as e:
@@ -169,7 +172,7 @@ def run(
             except SystemExit as result:
                 print(f"result {result}")
         elif workflow == WorkflowType.script:
-            subprocess.run(f"{path}", capture_output=True, check=True)
+            subprocess.run(f"{path.resolve()}", capture_output=True, check=True)
 
         connection.send_status(dataset_id, stage=stage, state=State.SUCCESS)
     except Exception as e:

--- a/crunch/django/app/models.py
+++ b/crunch/django/app/models.py
@@ -145,7 +145,7 @@ class Project(Item):
     workflow = models.TextField(
         default="",
         blank=True,
-        help_text="URL to snakemake repository or text of snakefile.",
+        help_text="URL to snakemake repository/shell script or its content.",
     )
     # More workflow languages need to be supported.
     # TODO assert parent is none

--- a/crunch/django/app/storages.py
+++ b/crunch/django/app/storages.py
@@ -63,7 +63,7 @@ def storage_walk_old(base="/", storage=None, error_handler=None):
 
         new_base = Path(base, subfolder)
         for f in storage_walk(
-            base=new_base, storage=storage, error_handler=error_handler
+            base_path=new_base, storage=storage, error_handler=error_handler
         ):
             yield f
 
@@ -124,7 +124,7 @@ class StorageDirectory(NodeMixin):
         """Does a pre order iteration of subdirectories."""
         return PreOrderIter(
             self,
-            filter=lambda node: isinstance(node, StorageDirectory),
+            filter_=lambda node: isinstance(node, StorageDirectory),
             stop=stop,
             maxlevel=maxlevel,
         )
@@ -133,7 +133,7 @@ class StorageDirectory(NodeMixin):
         """Does a pre order iteration of subdirectories and returns the files in them."""
         return PreOrderIter(
             self,
-            filter=lambda node: isinstance(node, StorageFile),
+            filter_=lambda node: isinstance(node, StorageFile),
             stop=stop,
             maxlevel=maxlevel,
         )
@@ -190,7 +190,7 @@ def storage_walk(
 
         new_base = Path(base_path, subfolder)
         storage_walk(
-            base=new_base,
+            base_path=new_base,
             storage=storage,
             error_handler=error_handler,
             parent=directory,
@@ -244,7 +244,7 @@ def copy_recursive_from_storage(base="/", local_dir=".", storage=None):
     if storage is None:
         storage = default_storage
 
-    dir_object = storage_walk(base=base, storage=storage)
+    dir_object = storage_walk(base_path=base, storage=storage)
     subdirs = dir_object.directory_descendents()
 
     for subdir in subdirs:


### PR DESCRIPTION
The user now specifies the path to a workflow using `crunch run [...] --path path/to/Snakefile`. Optionally, the user can also now specify a shell script (with an appropriate shebang line) or executable to run instead of a Snakefile by passing `--script`.

This PR also fixes a number of bugs:

1. `project_data` in `main.py/run()` referenced a non-existent field.
2. `storages.py` had broken calls to both `storage_walk` and `PreOrderIter`.

Closes #1