### PR TITLE
:bug: fix dataset_detail url NoReverseMatch error

### DIFF
--- a/crunch/templates/crunch/dataset_detail.html
+++ b/crunch/templates/crunch/dataset_detail.html
@@ -24,7 +24,7 @@
                 <i class="fas fa-edit"></i>
             </a>
         {% endif %}
-        <a href="{% url 'crunch:api:dataset-detail' slug=dataset.slug %}" class="btn btn-outline-primary btn-sm chk-saved" data-toggle="tooltip" data-placement="bottom" title="JSON">
+        <a href="{% url 'crunch:dataset-detail' slug=dataset.slug project=dataset.parent.slug %}" class="btn btn-outline-primary btn-sm chk-saved" data-toggle="tooltip" data-placement="bottom" title="JSON">
           <i class="fas fa-code"></i>
         </a>
         {% if request.user.is_staff %}


### PR DESCRIPTION
The dataset_details template was incorrectly resolving the url for details. This PR fixes the issue.